### PR TITLE
[fix/vesperae_preces_order] custom intentions before dead people inte…

### DIFF
--- a/src/modules/app/components/organism/prayers/VesperaePage.vue
+++ b/src/modules/app/components/organism/prayers/VesperaePage.vue
@@ -100,15 +100,27 @@
         <h4 class="title title-color">{{ $t('preces') }}</h4>
         <p v-html="formatText(prayer?.preces_intro)"></p>
         <p v-html="formatText(prayer?.preces_respuesta)"></p>
-        <div v-for="item in prayer?.preces_contenido"
-             v-bind:key="item" class="preces">
+
+        <div 
+          v-for="(item, index) in prayer?.preces_contenido.slice(0, -1)" 
+          :key="`preces-${index}`" 
+          class="preces"
+        >
           <p v-html="formatPrayers(item)"></p>
         </div>
 
         <div class="preces">
           <p class="title-color">{{ $t('explanationPreces') }}</p>
         </div>
+
         <CustomPrayersBlock/>
+
+        <div 
+          v-if="prayer?.preces_contenido?.length" 
+          class="preces"
+        >
+          <p v-html="formatPrayers(prayer.preces_contenido[prayer.preces_contenido.length - 1])"></p>
+        </div>
 
         <h4 class="title title-color">{{ $t('ourLord') }}</h4>
         <p class="margin-y-md">


### PR DESCRIPTION
I have changed vesperae page interface to place custom intentions before the dead people intention, which is always the last to be prayed. 

I also have check the change visually launching the project locally. 
<img width="1823" height="807" alt="fix_vesperae_preces_order" src="https://github.com/user-attachments/assets/4ed5e725-25a1-425e-9f1f-f528c4000877" />

